### PR TITLE
Fixed "Access violation" when removing two or more lines (#6)

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1142,7 +1142,7 @@ void __fastcall TX584Form::DeleteItemClick(TObject *Sender)
             SelLength = SelEnd - SelStart;
             //сдвигаем все инструкции на SelCount позиций влево
             for (int i = SelStart; i < MAX_ADDR; i++)
-                if (i < SelEnd) {
+                if (i + SelLength < MAX_ADDR) {
                     Code[i] = Code[i + SelLength];
                     CodeListView->Items->Item[i]->SubItems->Strings[1] =
                         CodeListView->Items->Item[i + SelLength]->SubItems->Strings[1];

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -217,6 +217,7 @@ __published:	// IDE-managed Components
     void __fastcall HelpItemClick(TObject *Sender);
     void __fastcall AboutItemClick(TObject *Sender);
 private:	// User declarations
+    void GetSelection(int &SelStart, int &SelEnd);
 public:		// User declarations
     K584 CPU;                           //объект процессора
     unsigned Code[MAX_ADDR];            //массив инструкций
@@ -226,7 +227,6 @@ public:		// User declarations
     TButton *ResButton;                 //предыдущая выделенная кнопка фильтра результатов
     unsigned Regs[12];                  //регистры и шины
     unsigned InFlags, OutFlags;         //входные и выходные флаги
-    int SelStart;                       //номер первой выделенной строки
     int SelCount;                       //количество выделенных строк
     unsigned MIClipboard[MAX_ADDR];     //буфер обмена для микроинструкций
     AnsiString CMClipboard[MAX_ADDR];   //буфер обмена для комментариев

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -226,6 +226,7 @@ public:		// User declarations
     TButton *ResButton;                 //предыдущая выделенная кнопка фильтра результатов
     unsigned Regs[12];                  //регистры и шины
     unsigned InFlags, OutFlags;         //входные и выходные флаги
+    int SelStart;                       //номер первой выделенной строки
     int SelCount;                       //количество выделенных строк
     unsigned MIClipboard[MAX_ADDR];     //буфер обмена для микроинструкций
     AnsiString CMClipboard[MAX_ADDR];   //буфер обмена для комментариев


### PR DESCRIPTION
At issue #6 I mentioned that when I deleted two or more lines selected with pressed Shift key, I receive an error message which reads "Access violation...". Since `CodeListView->ItemIndex == -1` when multiple elements are selected, I inserted a selection start mark and fixed instruction delete routine.