### PR TITLE
[v2.0] Fix comment parsing

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -300,7 +300,7 @@ UnicodeString NextWord(UnicodeString str, int &pos)
     while (pos <= str.Length() && str[pos] != L' ')
         pos++;
     //выделяем слово
-    return UpperCase(str.SubString(org, pos - org));
+    return AnsiUpperCase(str.SubString(org, pos - org));
 }
 
 const UnicodeString FlagNames[12] = {L"ПАЛУ3", L"!СДЛ1", L"!СДП1", L"!СДЛ2", L"!СДП2",


### PR DESCRIPTION
Since `AnsiUpperCase`, according to the [documentation](https://docwiki.embarcadero.com/Libraries/Sydney/en/System.SysUtils.AnsiUpperCase), receives `System::UnicodeString` and "supports multi-byte character sets", it should be used instead of `UpperCase` which converts only ASCII symbols.

This pull-request has been created instead of erroneous one (#18) and fixes issue (#17)