### PR TITLE
[v2.0] Add multiselect and fix CodeListView behavior (#15)

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -608,15 +608,14 @@ void __fastcall TX584Form::CodeListViewAdvancedCustomDrawItem(TCustomListView *S
     TRect Rectangle = Item->DisplayRect(drBounds);
     TRect TextRectangle;
 
-    int LastColumnIndex = CodeListView->Columns->Count - 2;
-    for (int i = 0; i <= LastColumnIndex; i++) {
+    for (int i = 1; i < CodeListView->Columns->Count; i++) {
         TTextFormat format = TTextFormat();
 
-        Rectangle.Left += CodeListView->Columns->Items[i]->Width;
-        Rectangle.Right = Rectangle.Left + CodeListView->Columns->Items[i+1]->Width;
+        Rectangle.Left += CodeListView->Columns->Items[i-1]->Width;
+        Rectangle.Right = Rectangle.Left + CodeListView->Columns->Items[i]->Width;
         TextRectangle = Rectangle;
 
-        switch (CodeListView->Columns->Items[i+1]->Alignment) {
+        switch (CodeListView->Columns->Items[i]->Alignment) {
         case taLeftJustify:
             format = format << tfLeft;
             TextRectangle.Left += 7;
@@ -636,7 +635,7 @@ void __fastcall TX584Form::CodeListViewAdvancedCustomDrawItem(TCustomListView *S
         format = format << tfEndEllipsis;
         format = format << tfNoPrefix;
 
-        UnicodeString str = Item->SubItems->Strings[i];
+        UnicodeString str = Item->SubItems->Strings[i-1];
         CodeListView->Canvas->TextRect(TextRectangle, str, format);
     }
 }

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1183,11 +1183,10 @@ void TX584Form::ClearSelectedItems()
 
 void TX584Form::RemoveSelectedItems()
 {
-    int NewIndex = 0;
-    int OldIndex = 0;
+    int OldIndex, NewIndex;
 
-    for (; OldIndex < MAX_ADDR && NewIndex < MAX_ADDR; OldIndex++) {
-        if (CodeListView->Items->Item[OldIndex]->Selected) {
+    for (OldIndex = 0, NewIndex = 0; OldIndex < MAX_ADDR && NewIndex < MAX_ADDR; OldIndex++) {
+        if (!CodeListView->Items->Item[OldIndex]->Selected) {
             TListItem *ItemOld, *ItemNew;
             Code[NewIndex] = Code[OldIndex];
             ItemOld = CodeListView->Items->Item[OldIndex];

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1106,24 +1106,25 @@ void TX584Form::RemoveSelectedItems()
         NewItems[Index] = false;
     }
 
-    int i = 0, j = 0;
-    for (; i < MAX_ADDR && j < MAX_ADDR; i++, j++) {
-        if (!NewItems[i]) {
-            j++;
-        }
-        Code[i] = Code[j];
+    int NewIndex = 0;
+    int OldIndex = 0;
 
-        TListItem *ItemA, *ItemB;
-        ItemA = CodeListView->Items->Item[i];
-        ItemB = CodeListView->Items->Item[j];
-        ItemA->SubItems->Strings[1] = ItemB->SubItems->Strings[1];
-        ItemA->SubItems->Strings[2] = ItemB->SubItems->Strings[2];
+    for (; OldIndex < MAX_ADDR && NewIndex < MAX_ADDR; OldIndex++) {
+        if (NewItems[OldIndex]) {
+            TListItem *ItemOld, *ItemNew;
+            Code[NewIndex] = Code[OldIndex];
+            ItemOld = CodeListView->Items->Item[OldIndex];
+            ItemNew = CodeListView->Items->Item[NewIndex];
+            ItemNew->SubItems->Strings[1] = ItemOld->SubItems->Strings[1];
+            ItemNew->SubItems->Strings[2] = ItemOld->SubItems->Strings[2];
+            NewIndex++;
+        }
     }
 
-    for (; i < MAX_ADDR; i++) {
-        Code[i] = NOP;
-        CodeListView->Items->Item[i]->SubItems->Strings[1] = NOP_TEXT;
-        CodeListView->Items->Item[i]->SubItems->Strings[2] = L"";
+    for (; NewIndex < MAX_ADDR; NewIndex++) {
+        Code[NewIndex] = NOP;
+        CodeListView->Items->Item[NewIndex]->SubItems->Strings[1] = NOP_TEXT;
+        CodeListView->Items->Item[NewIndex]->SubItems->Strings[2] = L"";
     }
 }
 //---------------------------------------------------------------------------

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -610,6 +610,7 @@ void __fastcall TX584Form::CodeListViewAdvancedCustomDrawItem(TCustomListView *S
         format = format << tfVerticalCenter;
         format = format << tfSingleLine;
         format = format << tfEndEllipsis;
+        format = format << tfNoPrefix;
 
         UnicodeString str = Item->SubItems->Strings[i];
         CodeListView->Canvas->TextRect(TextRectangle, str, format);

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1080,7 +1080,7 @@ void __fastcall TX584Form::ExitItemClick(TObject *Sender)
 
 void __fastcall TX584Form::CutItemClick(TObject *Sender)
 {
-    if (ActiveControl == CodeListView && !InputEdit->Visible) {
+    if ((ActiveControl == CodeListView || ActiveControl == CodeTreeView) && !InputEdit->Visible) {
         CopyItemClick(this);
         DeleteItemClick(this);
     } else
@@ -1118,9 +1118,10 @@ void TX584Form::CopySelectedItems()
     }
 }
 //---------------------------------------------------------------------------
+
 void __fastcall TX584Form::CopyItemClick(TObject *Sender)
 {
-    if (ActiveControl == CodeListView && !InputEdit->Visible) {
+    if ((ActiveControl == CodeListView || ActiveControl == CodeTreeView) && !InputEdit->Visible) {
         //сохраняем инструкции в буфере обмена
         CopySelectedItems();
         PutIntoClipboard();
@@ -1133,7 +1134,7 @@ void __fastcall TX584Form::CopyItemClick(TObject *Sender)
 
 void __fastcall TX584Form::PasteItemClick(TObject *Sender)
 {
-    if (ActiveControl == CodeListView && !InputEdit->Visible) {
+    if ((ActiveControl == CodeListView || ActiveControl == CodeTreeView) && !InputEdit->Visible) {
         GetFromClipboard();
         int index = CodeListView->ItemFocused->Index;
         if (InsertItem->Checked)
@@ -1159,7 +1160,7 @@ void __fastcall TX584Form::PasteItemClick(TObject *Sender)
 
         CodeListView->Repaint();
         SetModifyFlag(true);
-    } else*/
+    } else
         PostMessageW(ActiveControl->Handle, WM_PASTE, 0, 0);
 }
 //---------------------------------------------------------------------------
@@ -1220,7 +1221,7 @@ void TX584Form::ClearSelection()
 //---------------------------------------------------------------------------
 void __fastcall TX584Form::DeleteItemClick(TObject *Sender)
 {
-    if (ActiveControl == CodeListView && !InputEdit->Visible) {
+    if ((ActiveControl == CodeListView || ActiveControl == CodeTreeView) && !InputEdit->Visible) {
         if (InsertItem->Checked) {
             RemoveSelectedItems();
             //снимаем выделение

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -803,7 +803,8 @@ void __fastcall TX584Form::CodeListViewDragOver(TObject *Sender,
         Accept = TreeView->Selected->Count == 0;
         if (Accept) {
             //выделяем элемент, над которым перемещается указатель мыши
-            int Row = CodeListView->TopItem->Index + (Y - CodeListView->TopItem->Position.y) / LeftImageList->Height;
+            int RowHeight = CodeListView->TopItem->DisplayRect(drBounds).Height();
+            int Row = CodeListView->TopItem->Index + (Y - CodeListView->TopItem->Position.y) / RowHeight;
             if (Row >= MAX_ADDR)
                 Row = MAX_ADDR - 1;
             ClearSelection();

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -804,6 +804,7 @@ void __fastcall TX584Form::CodeTreeViewDblClick(TObject *Sender)
         CodeListView->Items->Item[pos]->SubItems->Strings[2] = L"";
         if (++pos >= MAX_ADDR)
             pos = MAX_ADDR - 1;
+        ClearSelection();
         CodeListView->ItemIndex = pos;
         CodeListView->ItemFocused = CodeListView->Items->Item[pos];
         CodeListView->Repaint();
@@ -1139,12 +1140,11 @@ void TX584Form::ClearSelection()
     FirstItem = Item = CodeListView->Selected;
 
     if (FirstItem) {
+        FirstItem->Selected = false;
         TItemStates selected = TItemStates() << isSelected;
         for (; Item; Item = CodeListView->GetNextItem(Item, sdBelow, selected)) {
             Item->Selected = false;
         }
-        FirstItem->Selected = true;
-        CodeListView->ItemFocused = FirstItem;
     }
 }
 //---------------------------------------------------------------------------
@@ -1152,9 +1152,11 @@ void __fastcall TX584Form::DeleteItemClick(TObject *Sender)
 {
     if (ActiveControl == CodeListView && !InputEdit->Visible) {
         if (InsertItem->Checked) {
+            TListItem *ItemFocused = CodeListView->ItemFocused;
             RemoveSelectedItems();
             //снимаем выделение
             ClearSelection();
+            ItemFocused->Selected = true;
         } else {
             ClearSelectedItems();
         }
@@ -1217,6 +1219,7 @@ void __fastcall TX584Form::ResetItemClick(TObject *Sender)
     ClearSelection();
     CodeListView->ItemIndex = 0;
     CodeListView->ItemFocused = CodeListView->Items->Item[0];
+    CodeListView->ItemFocused->Selected = true;
     CodeListView->Repaint();
     Terminated = true;
 }

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -585,7 +585,8 @@ void __fastcall TX584Form::CodeListViewAdvancedCustomDrawItem(TCustomListView *S
     TRect Rectangle = Item->DisplayRect(drBounds);
     TRect TextRectangle;
 
-    for (int i = 0; i <= 2; i++) {
+    int LastColumnIndex = CodeListView->Columns->Count - 2;
+    for (int i = 0; i <= LastColumnIndex; i++) {
         TTextFormat format = TTextFormat();
 
         Rectangle.Left += CodeListView->Columns->Items[i]->Width;

--- a/Sources/Main.dfm
+++ b/Sources/Main.dfm
@@ -58,6 +58,7 @@ object X584Form: TX584Form
     SmallImages = EmptyImageList
     TabOrder = 0
     ViewStyle = vsReport
+    OnAdvancedCustomDrawItem = CodeListViewAdvancedCustomDrawItem
     OnCustomDrawItem = CodeListViewCustomDrawItem
     OnDblClick = CodeListViewDblClick
     OnDragDrop = CodeListViewDragDrop

--- a/Sources/Main.dfm
+++ b/Sources/Main.dfm
@@ -53,6 +53,8 @@ object X584Form: TX584Form
         MinWidth = 100
         Width = 200
       end>
+    HideSelection = False
+    MultiSelect = True
     SmallImages = EmptyImageList
     TabOrder = 0
     ViewStyle = vsReport

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -42,6 +42,7 @@
 #include <Vcl.ImageCollection.hpp>
 #include <Vcl.VirtualImageList.hpp>
 #include <Winapi.Messages.hpp>
+#include <vector>
 //---------------------------------------------------------------------------
 
 #define MAX_ADDR        1024
@@ -229,6 +230,7 @@ __published:	// IDE-managed Components
     void __fastcall AboutItemClick(TObject *Sender);
 private:	// User declarations
     // Для обработки выбора элемента
+    std::vector<TListItem*> GetSelectedItems();
     void CopySelectedItems();
     void ClearSelectedItems();
     void RemoveSelectedItems();

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -178,6 +178,8 @@ __published:	// IDE-managed Components
     void __fastcall ApplicationEventsIdle(TObject *Sender, bool &Done);
     void __fastcall CodeListViewCustomDrawItem(TCustomListView *Sender,
           TListItem *Item, TCustomDrawState State, bool &DefaultDraw);
+    void __fastcall CodeListViewAdvancedCustomDrawItem(TCustomListView *Sender, TListItem *Item,
+          TCustomDrawState State, TCustomDrawStage Stage, bool &DefaultDraw);
     void __fastcall CodeListViewMouseDown(TObject *Sender,
           TMouseButton Button, TShiftState Shift, int X, int Y);
     void __fastcall CodeListViewDblClick(TObject *Sender);
@@ -193,7 +195,7 @@ __published:	// IDE-managed Components
           int X, int Y, TDragState State, bool &Accept);
     void __fastcall CodeListViewDragDrop(TObject *Sender, TObject *Source,
           int X, int Y);
-    void __fastcall CodeTreeViewChange(TObject *Sender, TTreeNode *Node);          
+    void __fastcall CodeTreeViewChange(TObject *Sender, TTreeNode *Node);
     void __fastcall CodeTreeViewDblClick(TObject *Sender);
     void __fastcall CodeTreeViewExpanded(TObject *Sender, TTreeNode *Node);
     void __fastcall CodeTreeViewCollapsed(TObject *Sender,
@@ -223,7 +225,6 @@ __published:	// IDE-managed Components
     void __fastcall ResetItemClick(TObject *Sender);
     void __fastcall HelpItemClick(TObject *Sender);
     void __fastcall AboutItemClick(TObject *Sender);
-
 private:	// User declarations
     void CopySelectedItems();
     void ClearSelectedItems();

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -225,12 +225,11 @@ __published:	// IDE-managed Components
     void __fastcall AboutItemClick(TObject *Sender);
 
 private:	// User declarations
-    void GetSelection(int &SelStart, int &SelEnd);
-
     void CopySelectedItems();
     void ClearSelectedItems();
     void RemoveSelectedItems();
     void ClearSelection();
+    int PreviousSelected;
 public:		// User declarations
     K584 CPU;                           //объект процессора
     unsigned Code[MAX_ADDR];            //массив инструкций
@@ -240,7 +239,6 @@ public:		// User declarations
     TButton *ResButton;                 //предыдущая выделенная кнопка фильтра результатов
     unsigned Regs[12];                  //регистры и шины
     unsigned InFlags, OutFlags;         //входные и выходные флаги
-    int SelCount;                       //количество выделенных строк
     unsigned MIClipboard[MAX_ADDR];     //буфер обмена для микроинструкций
     UnicodeString CMClipboard[MAX_ADDR];//буфер обмена для комментариев
     int ClipboardSize;                  //размер буфера обмена

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -226,6 +226,11 @@ __published:	// IDE-managed Components
 
 private:	// User declarations
     void GetSelection(int &SelStart, int &SelEnd);
+
+    void CopySelectedItems();
+    void ClearSelectedItems();
+    void RemoveSelectedItems();
+    void ClearSelection();
 public:		// User declarations
     K584 CPU;                           //объект процессора
     unsigned Code[MAX_ADDR];            //массив инструкций


### PR DESCRIPTION
List View from Common Controls 5.0 was very dumb and most of code in CodeListView event handlers was written to made it more smarter. Modern List View from Common Controls 6.10 and newer is smarter and its behavior interfered with old code so I mostly fixed it.

Another important addition is processing of multiselect and selection of non-consecutive lines with Ctrl+Click.

Another change is adding rendering the text inside `CodeListViewAdvancedCustomDrawItem` to intercept standard drawing routines of new versions of ListView.