### PR TITLE
[v2.0] Fix scrolling CodeListView when InputEdit is active (#16) for 2.0

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -555,6 +555,13 @@ void __fastcall TX584Form::ApplicationEventsIdle(TObject *Sender,
     StatusBar->Panels->Items[1]->Text = GetKeyState(VK_CAPITAL) & 1 ? L"CAP" : L"";
     StatusBar->Panels->Items[2]->Text = GetKeyState(VK_NUMLOCK) & 1 ? L"NUM" : L"";
     StatusBar->Panels->Items[3]->Text = GetKeyState(VK_SCROLL) & 1 ? L"SCRL" : L"";
+
+    if (InputEdit->Visible &&
+        (LastTopItem != CodeListView->TopItem || LastItemLeft != CodeListView->TopItem->Left))
+    {
+        InputEditExit(this);
+    }
+
     Done = true;
 }
 
@@ -761,6 +768,8 @@ void __fastcall TX584Form::ClickTimerTimer(TObject *Sender)
     //если мышь не покинула пределы строки после щелчка, начинаем редактирование
     TPoint Point = ScreenToClient(Mouse->CursorPos);
     if (Point.x >= EditPoint.x && Point.y >= EditPoint.y && Point.y < EditPoint.y + LeftImageList->Height) {
+        LastTopItem = CodeListView->TopItem;
+        LastItemLeft = LastTopItem->Left;
         InputEdit->Left = EditPoint.x;
         InputEdit->Top = EditPoint.y + (LeftImageList->Height - InputEdit->Height) / 2;
         int w1 = CodeListView->Canvas->TextWidth(CodeListView->Items->Item[EditRow]->SubItems->Strings[2]) + 8;

--- a/Sources/Main.h
+++ b/Sources/Main.h
@@ -228,6 +228,10 @@ __published:	// IDE-managed Components
 private:	// User declarations
     void GetSelection(int &SelStart, int &SelEnd);
 
+    // Для отслеживания положения CodeListView
+    TListItem *LastTopItem;
+    int LastItemLeft;
+
     // Для буфера обмена
     unsigned ClipboardFormat;
     void PutIntoClipboard();


### PR DESCRIPTION
Bug described in #16 is common for 1.31 and 2.0 versions of X584. It has been fixed for 1.x but not for 2.0.