### PR TITLE
Set focus to CodeListView when pasting instructions

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -873,6 +873,7 @@ void __fastcall TX584Form::CodeTreeViewChange(TObject *Sender,
 
 void __fastcall TX584Form::CodeTreeViewDblClick(TObject *Sender)
 {
+    CodeListView->SetFocus();
     TTreeNode *Node = CodeTreeView->Selected;
     if (!Node->Count) {
         int pos = CodeListView->ItemFocused->Index;


### PR DESCRIPTION
Fix bug described in #39