### PR TITLE
[v2.x] Fix resetting of selection

### DIFF
--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1488,9 +1488,8 @@ void __fastcall TX584Form::ResetItemClick(TObject *Sender)
         dynamic_cast<TCheckBox *>(FindComponent(L"OutFlags" + IntToStr(i)))->Checked = i >= 1 && i <= 4;
     //перерисовываем редактор кода
     Instruction = 0;
-    CodeListView->ItemFocused = NULL;
-    CodeListView->Selected = NULL;
-    CodeListView->Selected = CodeListView->Items->Item[0];
+    CodeListView->ItemFocused = CodeListView->Items->Item[0];
+    ClearSelection();
     PreviousSelected = 0;
     CodeListView->Repaint();
     Terminated = true;

--- a/Sources/Main.cpp
+++ b/Sources/Main.cpp
@@ -1488,10 +1488,10 @@ void __fastcall TX584Form::ResetItemClick(TObject *Sender)
         dynamic_cast<TCheckBox *>(FindComponent(L"OutFlags" + IntToStr(i)))->Checked = i >= 1 && i <= 4;
     //перерисовываем редактор кода
     Instruction = 0;
-    ClearSelection();
-    CodeListView->ItemIndex = 0;
-    CodeListView->ItemFocused = CodeListView->Items->Item[0];
-    CodeListView->ItemFocused->Selected = true;
+    CodeListView->ItemFocused = NULL;
+    CodeListView->Selected = NULL;
+    CodeListView->Selected = CodeListView->Items->Item[0];
+    PreviousSelected = 0;
     CodeListView->Repaint();
     Terminated = true;
 }


### PR DESCRIPTION
When I reset a program, selection to previous line was present.

> [!NOTE]
> There is another bug where old position is saved when selecting multiple items. It seems that there's a bug in TListView