### PR TITLE
[v2.x] X584 help amendments

### DIFF
--- a/Help/Using/commands.htm
+++ b/Help/Using/commands.htm
@@ -92,7 +92,7 @@
   
   <h3><a name="break">Команда «Пауза»</a></h3>
   <p class="button"><strong>Кнопка: <img src="break.png" width="32" height="32"></strong></p>
-  <p>Приостановка выполнения микропрограммы с сохранением исходных состояний.</p>
+  <p>Приостановка выполнения микропрограммы с сохранением текущего состояния.</p>
   <h3><a name="reset">Команда «Сброс»</a></h3>
   <p class="button"><strong>Кнопка: <img src="reset.png" width="32" height="32"></strong></p>
   <p class="hotkey"><strong><i>«Горячая» клавиша:</i> </strong> <strong>Ctrl+</strong><strong>F2</strong></p>

--- a/Help/Using/commands.htm
+++ b/Help/Using/commands.htm
@@ -88,7 +88,7 @@
   <h3><a name="run_to_cursor">Команда «Пуск до курсора»</a></h3>
   <p class="button"><strong>Кнопка: <img width="32" height="32" src="run_until.png"></strong></p>
   <p class="hotkey"><strong><i>«Горячая» клавиша:</i> </strong> <strong>F4</strong></p>
-  <p>Пуск до курсора, т.е. выполнение программы до курсора. </p>
+  <p>Выполняет программу до курсора выделения или до точки останова.</p>
   
   <h3><a name="break">Команда «Пауза»</a></h3>
   <p class="button"><strong>Кнопка: <img src="break.png" width="32" height="32"></strong></p>


### PR DESCRIPTION
Run until Cursor command description was following:
> Пуск до курсора, т.е. выполнение программы до курсора.

This description is self-repeating and doesn't describe what exactly this command do.

Also Pause command description states:
> Приостановка выполнения микропрограммы с сохранением исходных состояний.

"С сохранением исходных состояний" means that execution will be paused with saving of **initial** state, not **current** state.

I propose to change descriptions of these commands.
